### PR TITLE
Elasticsearch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # strongbox-janusgraph-cassandra-poc
+
+# Using Elasticsearch
+
+Elasticsearch is a part of this POC, as it is used by Janusgraph to support Mixed Index Queries.  It is configured via
+[elasticsearch-maven-plugin](https://github.com/alexcojocaru/elasticsearch-maven-plugin).  The plugin will automatically
+start the configured Elasticsearch instance when integration tests are run.  However, you can also use it to run
+Elasticsearch when running the application using `maven-sprint-boot-plugin`.
+
+To start both Elasticsearch and the spring-boot app, do the following:
+
+```
+$ mvn elasticsearch:runforked spring-boot:run
+```

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,24 @@
                             <goal>stop</goal>
                         </goals>
                     </execution>
+                    <!--
+                        Bind immediately before and after test phase since we are running
+                        integration tests here
+                    -->
+                    <execution>
+                        <id>test-start-elasticsearch</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>runforked</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-stop-elasticsearch</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
         <cassandra.version>3.11.4</cassandra.version>
         <tinkerpop.verion>3.4.4</tinkerpop.verion>
         <java.version>1.8</java.version>
+        <elasticsearch.port.rest>9200</elasticsearch.port.rest>
+        <elasticsearch.port.api>9300</elasticsearch.port.api>
     </properties>
 
     <dependencies>
@@ -40,6 +42,11 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
+            <version>${janusgraph.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-es</artifactId>
             <version>${janusgraph.version}</version>
         </dependency>
         <dependency>
@@ -98,7 +105,42 @@
                     <mainClass>org.carlspring.strongbox.janusgraph.app.Application</mainClass>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.31.0</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>elasticsearch</alias>
+                            <name>docker.elastic.co/elasticsearch/elasticsearch:6.8.4</name>
+                            <run>
+                                <ports>
+                                    <port>elasticsearch.port.rest:9200</port>
+                                    <port>elasticsearch.port.api:9300</port>
+                                </ports>
+                                <wait>
+                                    <http>
+                                        <url>http://${docker.host.address}:${elasticsearch.port.rest}/_cat/indices</url>
+                                        <method>GET</method>
+                                    </http>
+                                    <time>60000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <!--
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution> -->
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
         <tinkerpop.verion>3.4.4</tinkerpop.verion>
         <java.version>1.8</java.version>
         <elasticsearch.port.rest>9200</elasticsearch.port.rest>
-        <elasticsearch.port.api>9300</elasticsearch.port.api>
+        <elasticsearch.port.transport>9300</elasticsearch.port.transport>
+        <elasticsearch.version>6.8.4</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -106,39 +107,39 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.31.0</version>
+                <groupId>com.github.alexcojocaru</groupId>
+                <artifactId>elasticsearch-maven-plugin</artifactId>
+                <!--
+                    THE PLUGIN VERSION; FOR THE LIST OF AVAILABLE VERSIONS, SEE
+                    https://github.com/alexcojocaru/elasticsearch-maven-plugin/releases
+                -->
+                <version>6.14</version>
                 <configuration>
-                    <images>
-                        <image>
-                            <alias>elasticsearch</alias>
-                            <name>docker.elastic.co/elasticsearch/elasticsearch:6.8.4</name>
-                            <run>
-                                <ports>
-                                    <port>elasticsearch.port.rest:9200</port>
-                                    <port>elasticsearch.port.api:9300</port>
-                                </ports>
-                                <wait>
-                                    <http>
-                                        <url>http://${docker.host.address}:${elasticsearch.port.rest}/_cat/indices</url>
-                                        <method>GET</method>
-                                    </http>
-                                    <time>60000</time>
-                                </wait>
-                            </run>
-                        </image>
-                    </images>
+                    <!-- THE ELASTICSEARCH VERSION; REPLACE WITH THE VERSION YOU NEED -->
+                    <version>${elasticsearch.version}</version>
+                    <clusterName>test</clusterName>
+                    <transportPort>${elasticsearch.port.transport}</transportPort>
+                    <httpPort>${elasticsearch.port.rest}</httpPort>
                 </configuration>
                 <executions>
                     <!--
+                        The elasticsearch maven plugin goals are by default bound to the
+                        pre-integration-test and post-integration-test phases
+                    -->
                     <execution>
-                        <id>default-testCompile</id>
-                        <phase>test-compile</phase>
+                        <id>start-elasticsearch</id>
+                        <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>start</goal>
+                            <goal>runforked</goal>
                         </goals>
-                    </execution> -->
+                    </execution>
+                    <execution>
+                        <id>stop-elasticsearch</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,8 @@
             <plugin>
                 <groupId>com.github.alexcojocaru</groupId>
                 <artifactId>elasticsearch-maven-plugin</artifactId>
-                <!--
-                    THE PLUGIN VERSION; FOR THE LIST OF AVAILABLE VERSIONS, SEE
-                    https://github.com/alexcojocaru/elasticsearch-maven-plugin/releases
-                -->
                 <version>6.14</version>
                 <configuration>
-                    <!-- THE ELASTICSEARCH VERSION; REPLACE WITH THE VERSION YOU NEED -->
                     <version>${elasticsearch.version}</version>
                     <clusterName>test</clusterName>
                     <transportPort>${elasticsearch.port.transport}</transportPort>

--- a/src/main/java/org/carlspring/strongbox/janusgraph/graph/JanusGraphConfig.java
+++ b/src/main/java/org/carlspring/strongbox/janusgraph/graph/JanusGraphConfig.java
@@ -26,6 +26,10 @@ public class JanusGraphConfig
                                 .set("storage.port", cassandraEmbeddedProperties.getPort())
                                 .set("storage.cql.keyspace", "jgex")
                                 .set("tx.log-tx", true)
+                                .set("gremlin.graph", "org.janusgraph.core.JanusGraphFactoryGraphTraversalSource")
+                                .set("index.search.backend", "elasticsearch")
+                                .set("index.search.hostname", "127.0.0.1")
+                                .set("index.search.elasticsearch.client-only", "true")
                                 .open();
     }
 


### PR DESCRIPTION
This PR gets elasticsearch running during the build (test phase) and also allows running it alongside `mvn spring-boot:run`.