### PR TITLE
Revert "Elasticsearch config"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,1 @@
 # strongbox-janusgraph-cassandra-poc
-
-# Using Elasticsearch
-
-Elasticsearch is a part of this POC, as it is used by Janusgraph to support Mixed Index Queries.  It is configured via
-[elasticsearch-maven-plugin](https://github.com/alexcojocaru/elasticsearch-maven-plugin).  The plugin will automatically
-start the configured Elasticsearch instance when integration tests are run.  However, you can also use it to run
-Elasticsearch when running the application using `maven-sprint-boot-plugin`.
-
-To start both Elasticsearch and the spring-boot app, do the following:
-
-```
-$ mvn elasticsearch:runforked spring-boot:run
-```

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,6 @@
         <cassandra.version>3.11.4</cassandra.version>
         <tinkerpop.verion>3.4.4</tinkerpop.verion>
         <java.version>1.8</java.version>
-        <elasticsearch.port.rest>9200</elasticsearch.port.rest>
-        <elasticsearch.port.transport>9300</elasticsearch.port.transport>
-        <elasticsearch.version>6.8.4</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -43,11 +40,6 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
-            <version>${janusgraph.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.janusgraph</groupId>
-            <artifactId>janusgraph-es</artifactId>
             <version>${janusgraph.version}</version>
         </dependency>
         <dependency>
@@ -106,55 +98,7 @@
                     <mainClass>org.carlspring.strongbox.janusgraph.app.Application</mainClass>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.github.alexcojocaru</groupId>
-                <artifactId>elasticsearch-maven-plugin</artifactId>
-                <version>6.14</version>
-                <configuration>
-                    <version>${elasticsearch.version}</version>
-                    <clusterName>test</clusterName>
-                    <transportPort>${elasticsearch.port.transport}</transportPort>
-                    <httpPort>${elasticsearch.port.rest}</httpPort>
-                </configuration>
-                <executions>
-                    <!--
-                        The elasticsearch maven plugin goals are by default bound to the
-                        pre-integration-test and post-integration-test phases
-                    -->
-                    <execution>
-                        <id>start-elasticsearch</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>runforked</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>stop-elasticsearch</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                    <!--
-                        Bind immediately before and after test phase since we are running
-                        integration tests here
-                    -->
-                    <execution>
-                        <id>test-start-elasticsearch</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>runforked</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-stop-elasticsearch</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/java/org/carlspring/strongbox/janusgraph/graph/JanusGraphConfig.java
+++ b/src/main/java/org/carlspring/strongbox/janusgraph/graph/JanusGraphConfig.java
@@ -26,10 +26,6 @@ public class JanusGraphConfig
                                 .set("storage.port", cassandraEmbeddedProperties.getPort())
                                 .set("storage.cql.keyspace", "jgex")
                                 .set("tx.log-tx", true)
-                                .set("gremlin.graph", "org.janusgraph.core.JanusGraphFactoryGraphTraversalSource")
-                                .set("index.search.backend", "elasticsearch")
-                                .set("index.search.hostname", "127.0.0.1")
-                                .set("index.search.elasticsearch.client-only", "true")
                                 .open();
     }
 


### PR DESCRIPTION
Reverting strongbox/strongbox-janusgraph-cassandra-poc#5 because we should have optional embedded Elasticsearch.