### PR TITLE
Remove shutdown hooks for Cassandra and JanusGraph

### DIFF
--- a/src/main/java/org/carlspring/strongbox/janusgraph/cassandra/CassandraEmbeddedConfig.java
+++ b/src/main/java/org/carlspring/strongbox/janusgraph/cassandra/CassandraEmbeddedConfig.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.janusgraph.cassandra;
 import java.io.IOException;
 
 import org.apache.cassandra.service.CassandraDaemon;
+import org.apache.cassandra.service.StorageService;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -28,6 +29,9 @@ public class CassandraEmbeddedConfig
 
         CassandraDaemon cassandraDaemon = new CassandraDaemon(true);
         cassandraDaemon.activate();
+
+        // Remove Cassandra StorageService shutdown hook to allow Spring context to shutdown in order
+        StorageService.instance.removeShutdownHook();
 
         return cassandraDaemon;
     }


### PR DESCRIPTION
I was able to get an orderly shutdown by removing the self-registered shutdown hooks for Cassandra and JanusGraph.  Spring context will shut them down in the correct order.  There is no public access to the shutdown hook in JanusGraph, thus the use of reflection.